### PR TITLE
Allow names with more than one period

### DIFF
--- a/biosdisk
+++ b/biosdisk
@@ -473,7 +473,7 @@ while [ $# -gt 0 ]; do
 			    exit 1
 			fi
                         fileName=`basename $file | cut -d. -f1`
-                        fileExt=`basename $file | cut -d. -f2`                 
+                        fileExt=`basename $file | rev | cut -d. -f1 | rev`                 
                         case $fileExt in
                             img|IMG)
                                 imgCompleteFlag=1


### PR DESCRIPTION
Allows files such as `Latitude_E7x70_1.17.5.exe`