### PR TITLE
Increase supported image size from 8 to 20 MiB

### DIFF
--- a/biosdisk
+++ b/biosdisk
@@ -50,8 +50,9 @@ destination=""
 dosDisk144="$baseDir/dosdisk.img"
 dosDisk288="$baseDir/dosdisk288.img"
 dosDisk8192="$baseDir/dosdisk8192.img"
+dosDisk20480="$baseDir/dosdisk20480.img"
 geometry_8192="floppy c=8 s=32 h=64"
-dosDisk=$dosDisk8192
+dosDisk=$dosDisk20480
 geometry_floppy=$geometry_8192
 pkgSupported="Rpm, Dpkg"
 rpmBaseDir="$libDir/rpm"

--- a/biosdisk.spec
+++ b/biosdisk.spec
@@ -38,6 +38,7 @@ install -m 755 blconf %{buildroot}%{_sbindir}
 install -m 644 dosdisk.img %{buildroot}%{_datadir}/%{name}
 install -m 644 dosdisk288.img %{buildroot}%{_datadir}/%{name}
 install -m 644 dosdisk8192.img %{buildroot}%{_datadir}/%{name}
+install -m 644 dosdisk20480.img %{buildroot}%{_datadir}/%{name}
 install -m 644 biosdisk.conf %{buildroot}/%{_sysconfdir}
 install -m 644 biosdisk-mkrpm-redhat-template.spec %{buildroot}%{_datadir}/%{name}
 install -m 644 biosdisk-mkrpm-generic-template.spec %{buildroot}%{_datadir}/%{name}

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ install -m 755 blconf /usr/sbin
 install -m 644 dosdisk.img /usr/share/biosdisk
 install -m 644 dosdisk288.img /usr/share/biosdisk
 install -m 644 dosdisk8192.img /usr/share/biosdisk
+install -m 644 dosdisk20480.img /usr/share/biosdisk
 install -m 644 biosdisk.conf /etc/
 if [ -e /usr/bin/rpm ] || [ -e /bin/rpm ]; then
     install -m 644 biosdisk-mkrpm-redhat-template.spec /usr/share/biosdisk


### PR DESCRIPTION
Apparently E7440A22.exe is 10, see this user's error message: https://aur.archlinux.org/packages/biosdisk-git/